### PR TITLE
コース内観光場所修正時、表示順が異常となるバグ修正

### DIFF
--- a/app/controllers/course_routes_controller.rb
+++ b/app/controllers/course_routes_controller.rb
@@ -1,7 +1,7 @@
 class CourseRoutesController < ApplicationController
   def show
     @spots = Spot.includes(:area)
-    @course_route = CourseRoute.where(model_course_id: course_id)
+    @course_route = CourseRoute.course(course_id)
   end
 
   private

--- a/app/controllers/impressions_controller.rb
+++ b/app/controllers/impressions_controller.rb
@@ -1,12 +1,12 @@
 class ImpressionsController < ApplicationController
   def index
-    @impressions = Impression.includes(:my_schedule).order("created_at DESC")
+    @impressions = Impression.order(created_at: "DESC")
   end
 
   def new
     @choice_spot = MyTravelCourse.find(param_format)
-    @gone_date = MySchedule.find_by(id: @choice_spot.my_schedule_id).date
-    @spot_name = Spot.find(@choice_spot.spot_id).name
+    @gone_date = MySchedule.travel_date(@choice_spot)
+    @spot_name = Spot.id_name(@choice_spot)
   end
 
   def create

--- a/app/controllers/model_courses_controller.rb
+++ b/app/controllers/model_courses_controller.rb
@@ -12,10 +12,6 @@ class ModelCoursesController < ApplicationController
                                       .where(model_course_id: @courses_in_area.ids)
   end
 
-  def make_course
-    ModelCourse.make_model_course(@areas, @spots)
-  end
-
   private
 
   def area_id

--- a/app/controllers/model_courses_controller.rb
+++ b/app/controllers/model_courses_controller.rb
@@ -8,8 +8,7 @@ class ModelCoursesController < ApplicationController
   def show
     #選択したエリアのコースリストを選択
     @courses_in_area = ModelCourse.where(area_id: area_id)  
-    @model_course_routes = CourseRoute.includes(:model_course)
-                                      .where(model_course_id: @courses_in_area.ids)
+    @model_routes = CourseRoute.course_ids(@courses_in_area)
   end
 
   private

--- a/app/controllers/my_travel_courses_controller.rb
+++ b/app/controllers/my_travel_courses_controller.rb
@@ -1,7 +1,7 @@
 class MyTravelCoursesController < ApplicationController
   def show
     @spots = Spot.all_spots
-    @course = MyTravelCourse.where(my_schedule_id: my_schedule_id)
+    @course = MyTravelCourse.schedule_id(my_schedule_id)
     @schedule = MySchedule.find(params[:id])
   end
 
@@ -19,7 +19,7 @@ class MyTravelCoursesController < ApplicationController
   end
 
   def gone_flag
-    MySchedule.find(format_params).update(gone: true)
+    MySchedule.is_gone(format_params)
     redirect_to my_travel_course_path(format_params)
   end
 

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -4,7 +4,7 @@ class SpotsController < ApplicationController
   end
 
   def show
-    @spot = Spot.find(show_param.to_i)
+    @spot = Spot.find(show_param)
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,9 +8,8 @@ class UsersController < ApplicationController
   def show
     @spots = Spot.all_spots
     @want_spots = current_user.wanted_spots
-    my_schedules = MySchedule.where(user_id: current_user.id)
-    @gone_true_schedules = my_schedules.where(gone: true)
-    @gone_false_schedules = my_schedules.where(gone: false)
+    @gone_true_schedules = MySchedule.user_schedules(current_user, true)
+    @gone_false_schedules = MySchedule.user_schedules(current_user, false)
     @my_travel_courses = MyTravelCourse.includes(:my_schedule)
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,4 @@
 class UsersController < ApplicationController
-  helper_method :devided_my_travel_course
-  
   def index
     @users = User.all
   end
@@ -11,9 +9,5 @@ class UsersController < ApplicationController
     @gone_true_schedules = MySchedule.user_schedules(current_user, true)
     @gone_false_schedules = MySchedule.user_schedules(current_user, false)
     @my_travel_courses = MyTravelCourse.includes(:my_schedule)
-  end
-
-  def devided_my_travel_course(schedule)
-    @my_travel_courses.where(my_schedule_id: schedule.id)
   end
 end

--- a/app/helpers/impressions_helper.rb
+++ b/app/helpers/impressions_helper.rb
@@ -1,5 +1,2 @@
 module ImpressionsHelper
-  def gone_schedule(impression)
-    MySchedule.find(impression.my_schedule_id)
-  end
 end

--- a/app/models/course_route.rb
+++ b/app/models/course_route.rb
@@ -1,6 +1,8 @@
 class CourseRoute < ApplicationRecord
   belongs_to :model_course
   belongs_to :spot
+  scope :course_ids, -> (course) { where(model_course_id: course.ids) }
+  scope :course, -> (course_id) { where(model_course_id: course_id) }
 
   class << self
     def create_course_routes(model_course, a_path)

--- a/app/models/my_schedule.rb
+++ b/app/models/my_schedule.rb
@@ -2,4 +2,18 @@ class MySchedule < ApplicationRecord
   has_many :my_travel_courses, dependent: :destroy
   belongs_to :user
   has_many :impressions
+  scope :me, -> (user) { where(user_id: user.id) }
+  scope :is_gone, -> (gone) { where(gone: gone) }
+  scope :sort_asc, -> { order(order: "ASC").limit(5) }
+
+
+  class << self
+    def user_schedules(user, gone)
+      me(user).is_gone(gone).to_a
+    end
+
+    def sort_order
+      sort_asc
+    end
+  end
 end

--- a/app/models/my_schedule.rb
+++ b/app/models/my_schedule.rb
@@ -3,17 +3,14 @@ class MySchedule < ApplicationRecord
   belongs_to :user
   has_many :impressions
   scope :me, -> (user) { where(user_id: user.id) }
-  scope :is_gone, -> (gone) { where(gone: gone) }
-  scope :sort_asc, -> { order(order: "ASC").limit(5) }
-
+  scope :gone_flag, -> (gone) { where(gone: gone) }
+  scope :is_gone, -> (format) { find(format).update(gone: true) }
+  scope :find_id, -> (model) { find(model.my_schedule_id) }
+  scope :travel_date, -> (model) { find_id(model).date}
 
   class << self
     def user_schedules(user, gone)
-      me(user).is_gone(gone).to_a
-    end
-
-    def sort_order
-      sort_asc
+      me(user).gone_flag(gone).to_a
     end
   end
 end

--- a/app/models/my_travel_course.rb
+++ b/app/models/my_travel_course.rb
@@ -1,7 +1,7 @@
 class MyTravelCourse < ApplicationRecord
   belongs_to :my_schedule
   belongs_to :spot
-  scope :schedule_id, -> (schedule) { where(my_schedule_id: schedule.id).order(order: "ASC") }
+  scope :schedule_id, -> (schedule_id) { where(my_schedule_id: schedule_id).order(order: "ASC") }
 
 
   class << self

--- a/app/models/my_travel_course.rb
+++ b/app/models/my_travel_course.rb
@@ -1,6 +1,8 @@
 class MyTravelCourse < ApplicationRecord
   belongs_to :my_schedule
   belongs_to :spot
+  scope :schedule_id, -> (schedule) { where(my_schedule_id: schedule.id).order(order: "ASC") }
+
 
   class << self
     def gone_text(gone_flag)

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -4,6 +4,7 @@ class Spot < ApplicationRecord
   has_many :wanted_users, through: :wants, source: :user
   has_many :distances, dependent: :destroy
   has_many :course_routes, dependent: :destroy
+  scope :id_name -> (spot) { find(spot.spot_id).name }
 
   def wanted_by?(user)
     wants.where(user_id: user.id).exists?

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -4,7 +4,8 @@ class Spot < ApplicationRecord
   has_many :wanted_users, through: :wants, source: :user
   has_many :distances, dependent: :destroy
   has_many :course_routes, dependent: :destroy
-  scope :id_name -> (spot) { find(spot.spot_id).name }
+  scope :id_name, -> (spot) { find(spot.spot_id).name }
+  scope :id_description, -> (spot) { find(spot.spot_id).description }
 
   def wanted_by?(user)
     wants.where(user_id: user.id).exists?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ApplicationRecord
   has_many :wants, dependent: :destroy
   has_many :wanted_spots, through: :wants, source: :spot
   has_many :my_schedules
+  scope :id_name, -> (table) { find(table.user_id).nickname }
 end

--- a/app/views/course_routes/show.html.erb
+++ b/app/views/course_routes/show.html.erb
@@ -7,8 +7,8 @@
         <div class="col-12 col-md-6 col-lg-6">
           <div class="card border-dark mb-3">
             <div class="card-body">
-            <p><%= course_spot.order %>. <%= @spots.find(course_spot.spot_id).name %></p>
-            <p><%= @spots.find(course_spot.spot_id).description %></p>
+            <p><%= course_spot.order %>. <%= @spots.id_name(course_spot) %></p>
+            <p><%= @spots.id_description(course_spot) %></p>
             </div>
           </div>
         </div>

--- a/app/views/impressions/index.html.erb
+++ b/app/views/impressions/index.html.erb
@@ -1,6 +1,6 @@
 <% @impressions.each do |impression| %>
-  <p>投稿者：<%= User.find(gone_schedule(impression).user_id).nickname %></p>
-  <p>旅行日：<%= gone_schedule(impression).date %></p>
+  <p>投稿者：<%= User.id_name(MySchedule.find_id(impression)) %></p>
+  <p>旅行日：<%= MySchedule.find_id(impression).date %></p>
   <p>観光地名：<%= Spot.find(impression.spot_id).name %></p>
   <p>感想：<%= impression.text %></p>
   <p>投稿時間：<%= impression.created_at.to_s(:datetime_jp) %>

--- a/app/views/impressions/new.html.erb
+++ b/app/views/impressions/new.html.erb
@@ -1,7 +1,6 @@
-<h1>OK</h1>
 <%= form_with model: @choice_spot, url: impressions_path(@choice_spot), method: :post, local: true do |f| %>
-  <h1>日付：<%= @gone_date %>
-  <h1>観光地名：<%= @spot_name %></h1>
+  <h3>日付：<%= @gone_date %></h3>
+  <h3>観光地名：<%= @spot_name %></h3>
   <div class="field">
     <%= f.label :text, "感想の入力" %>
     <%= f.text_area :text %>

--- a/app/views/model_courses/show.html.erb
+++ b/app/views/model_courses/show.html.erb
@@ -1,8 +1,8 @@
 <% @courses_in_area.each do |course| %>
-  <% @model_course_routes.where(model_course_id: course.id).each do |course_spot| %>
-    <p><%= @spots.find(course_spot.spot_id).name %></p>
+  <% @model_routes.course(course.id).each do |course_spot| %>
+    <p><%= @spots.id_name(course_spot) %></p>
   <% end %>
-  <%= course.score %>
+  合計移動距離： <%= course.score.round(2) %> km
   <%= link_to "詳細を見る", course_route_path(course) %>
   <hr>
 <% end %>

--- a/app/views/my_travel_courses/edit.html.erb
+++ b/app/views/my_travel_courses/edit.html.erb
@@ -1,3 +1,1 @@
-<%= form_with model: @travel_spot, url: my_travel_course_path(@travel_spot), method: :patch, local: true do |f| %>
-  <%= render 'shared/all_spots_list', f: f %>
-<% end %>
+<%= render 'shared/all_spots_list' %>

--- a/app/views/my_travel_courses/show.html.erb
+++ b/app/views/my_travel_courses/show.html.erb
@@ -1,11 +1,10 @@
 <% @course.each do |spot| %>
   <p>
-    <%= spot.order %>. <%= @spots.id_name %>
+    <%= link_to "コースの修正", edit_my_travel_course_path(spot) %>
+    <%= spot.order %>. <%= @spots.id_name(spot) %>
     <% if @schedule.gone %>
       <%= link_to "感想の入力", new_impression_path(spot) %>
     <% else %>
-      <%= link_to "コースの修正", edit_my_travel_course_path(spot) %>
-    <% end %>
   </p>
 <% end %>
 <%= button_to "旅行終了", my_travel_courses_gone_flag_path(@schedule) %>

--- a/app/views/my_travel_courses/show.html.erb
+++ b/app/views/my_travel_courses/show.html.erb
@@ -1,6 +1,6 @@
 <% @course.each do |spot| %>
   <p>
-    <%= spot.order %>. <%= @spots.find(spot.spot_id).name %>
+    <%= spot.order %>. <%= @spots.id_name %>
     <% if @schedule.gone %>
       <%= link_to "感想の入力", new_impression_path(spot) %>
     <% else %>

--- a/app/views/users/_show_course.html.erb
+++ b/app/views/users/_show_course.html.erb
@@ -4,6 +4,6 @@
     <%= MyTravelCourse.gone_text(schedule.gone) %>
   </button>
 </p>
-<% @my_travel_courses.where(my_schedule_id: schedule.id).each do |spot| %>
-  <p><%= spot.order %>.  <%= @spots.find(spot.spot_id).name %></p>
+<% @my_travel_courses.schedule_id(schedule).each do |spot| %>
+  <p><%= spot.order %>.  <%= @spots.id_name(spot) %></p>
 <% end %>


### PR DESCRIPTION
closes #8 

# 内容
コースの3番目の観光場所を変更したとする。
表示順　　正）1,2,3,4,5
表示順　今回）1,2,4,5,3

回る順序で表示させたいため、順序のソートを行う

# 解決策
- course_routesテーブルにorderカラム（観光地に訪れる順番）があるため、このカラムの値でソートする
- その他、controller, viewメソッドをmodelにてscope化

# 動作確認
コース表示順が正の順番で表示されること確認

# 参考資料
[rails 昇順、降順の並び替え](https://qiita.com/tsuchinoko_run/items/c31ed7e0b0672e6d898a)
[名前付きスコープについての基本的なまとめ rails](https://qiita.com/kaba/items/fbf2cdce070e80d4be58)