### PR TITLE
感想画面表示　配置修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -46,7 +46,7 @@ body {
 }
 
 textarea:read-only {
-  border: none;
+  // border: none;
   resize: none;
   outline: none;
   width: 100%;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -88,6 +88,13 @@ img {
   }
 }
 
+.model-index-text {
+  font-size: 1.5em;
+  @media only screen and (max-width: 680px) {
+    font-size: 1em;
+  }
+}
+
 .logo-size {
   width: 25%;
   height: 25%;

--- a/app/controllers/impressions_controller.rb
+++ b/app/controllers/impressions_controller.rb
@@ -40,16 +40,13 @@ class ImpressionsController < ApplicationController
   end
 
   def message_is_empty
-    if params_impression[:text].empty?
-      flash[:danger] = "感想を入力してください。"
-      redirect_to new_impression_path(param_format)
-    end
+    redirect_to new_impression_path(param_format), danger: "感想を入力してください" unless params_impression[:text]
   end
 
   def message_length_over
-    if params_impression[:text].length > MAX_TEXT_LENGTH
-      flash[:danger] = "感想は300文字以内で入力してください"
-      render :new
-    end
+    return unless params_impression[:text].length > MAX_TEXT_LENGTH
+
+    flash[:danger] = "感想は300文字以内で入力してください"
+    render :new
   end
 end

--- a/app/controllers/impressions_controller.rb
+++ b/app/controllers/impressions_controller.rb
@@ -47,7 +47,7 @@ class ImpressionsController < ApplicationController
   end
 
   def message_length_over
-    if (params_impression[:text].length > MAX_TEXT_LENGTH)
+    if params_impression[:text].length > MAX_TEXT_LENGTH
       flash[:danger] = "感想は300文字以内で入力してください"
       render :new
     end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,7 +1,7 @@
 class SpotsController < ApplicationController
   def index
     @spots = Spot.includes(:area)
-    @wanted_spot_ids = current_user.wants.pluck(:spot_id) if current_user
+    @wanted_spot_ids = current_user.wanted_spots.pluck(:spot_id) if current_user
   end
 
   def show

--- a/app/models/my_travel_course.rb
+++ b/app/models/my_travel_course.rb
@@ -3,12 +3,4 @@ class MyTravelCourse < ApplicationRecord
   belongs_to :spot
   validates :order, numericality: { greater_than_or_equal_to: 1 }
   validates :fill_in_impression, inclusion: [true, false]
-
-  class << self
-    def gone_text(gone_flag)
-      return "旅行完了" if gone_flag
-
-      "旅行予定"
-    end
-  end
 end

--- a/app/views/course_routes/show.html.erb
+++ b/app/views/course_routes/show.html.erb
@@ -9,7 +9,7 @@
     <div class="col-12 col-md-6 col-lg-6 mx-auto mt-3">
       <div class="card border-dark mb-3">
         <div class="card-body">
-          <p><%= course_spot.order %>. <%= course_spot.spot.name %></p>
+          <%= render 'shared/travel_spot_name_and_order', course_spot: course_spot %>
           <p><%= course_spot.spot.description %></p>
           <%= image_tag "/assets/#{ course_spot.spot.image }", :size => '300x300' %>
         </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,30 +1,40 @@
-<div class="m-3 mx-5">
-  <h2>新規登録</h2>
-  <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-    <%= render "devise/shared/error_messages", resource: resource %>
-    <div class="field mt-2">
-      <%= f.label :nickname %><br />
-      <%= f.text_field :nickname, autofocus: true, autocomplete: "nickname" %>
+<div class="row">
+  <div class="col-12 col-sm-12 col-md-8 col-lg-6 text-center mx-auto">
+    <div class="card border border-0 mb-3 overflow-auto mx-auto">
+      <div class="mb-5">
+        <h2>新規登録</h2>
+      </div>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
+        <div class="field mt-2">
+          <%= f.label :nickname %>
+          <%= f.text_field :nickname, autofocus: true, autocomplete: "nickname" %>
+        </div>
+        <div class="field mt-2">
+          <%= f.label :email %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        </div>
+        <div class="field mt-2">
+          <%= f.label :password %>
+          <%= f.password_field :password, autocomplete: "new-password" %><br>
+          <% if @minimum_password_length %>
+            <div class="ml-5">
+              <em>(<%= @minimum_password_length %> 文字以上)</em>
+            </div>
+          <% end %>
+        </div>
+        <div class="field mt-2">
+          <%= f.label :password_confirmation %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+        </div>
+        <div class="actions mt-3">
+          <%= f.submit "新規登録", class: "btn btn-lg btn-success" %>
+        </div>
+      <% end %>
+      <%= render "devise/shared/links" %>
+      <div>
+        <%= link_to 'ゲストログイン（閲覧用）', users_guest_login_path, method: :post, class: "btn btn-sm btn-info" %>
+      </div>
     </div>
-    <div class="field mt-2">
-      <%= f.label :email %><br />
-      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-    </div>
-    <div class="field mt-2">
-      <%= f.label :password %>
-      <% if @minimum_password_length %>
-        <em>(<%= @minimum_password_length %> 文字以上)</em>
-      <% end %><br />
-      <%= f.password_field :password, autocomplete: "new-password" %>
-    </div>
-    <div class="field mt-2">
-      <%= f.label :password_confirmation %><br />
-      <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-    </div>
-    <div class="actions mt-3">
-      <%= f.submit "新規登録", class: "btn btn-lg btn-success" %>
-    </div>
-  <% end %>
-  <%= render "devise/shared/links" %>
-  <%= link_to 'ゲストログイン（閲覧用）', users_guest_login_path, method: :post, class: "btn btn-sm btn-info" %>
+  </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,31 +1,37 @@
-<div class="m-3 mx-5">
-  <h2>ログイン</h2>
-
-  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-    <div class="field mt-2">
-      <%= f.label :email %><br />
-      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-    </div>
-
-    <div class="field mt-2">
-      <%= f.label :password %><br />
-      <%= f.password_field :password, autocomplete: "current-password" %>
-    </div>
-
-    <% if devise_mapping.rememberable? %>
-      <div class="field mt-2">
-        <%= f.check_box :remember_me %>
-        <%= f.label :remember_me %>
+<div class="row">
+  <div class="col-12 col-sm-12 col-md-12 col-lg-6 text-center mx-auto">
+    <div class="card border border-0 mb-3 overflow-auto mx-auto">
+      <div class="mb-5">
+        <h2>ログイン</h2>
       </div>
-    <% end %>
 
-    <div class="actions mt-3">
-      <%= f.submit "ログイン", class: "btn btn-lg btn-success" %>
+      <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+        <div class="field mt-3">
+          <%= f.label :email %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        </div>
+
+        <div class="field mt-3">
+          <%= f.label :password %>
+          <%= f.password_field :password, autocomplete: "current-password" %>
+        </div>
+
+        <% if devise_mapping.rememberable? %>
+          <div class="field mt-3">
+            <%= f.check_box :remember_me %>
+            <%= f.label :remember_me %>
+          </div>
+        <% end %>
+
+        <div class="actions mt-4 mx-auto">
+          <%= f.submit "ログイン", class: "btn btn-lg btn-success" %>
+        </div>
+      <% end %>
+
+      <%= render "devise/shared/links" %>
+      <div>
+        <%= link_to 'ゲストログイン（閲覧用）', users_guest_login_path, method: :post, class: "btn btn-sm btn-info" %>
+      </div>
     </div>
-  <% end %>
-
-  <%= render "devise/shared/links" %>
-  <div class="mt-4">
-    <%= link_to 'ゲストログイン（閲覧用）', users_guest_login_path, method: :post, class: "btn btn-sm btn-info" %>
   </div>
 </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,34 +1,34 @@
-<div class="mt-4">
+<div class="mt-3">
   <%- if controller_name != 'sessions' %>
     <%= link_to "ログイン", new_session_path(resource_name), class: "btn btn-sm btn-info" %><br />
   <% end %>
 </div>
 
-<div class="mt-4">
+<div class="mt-3">
   <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
     <%= link_to "新規登録", new_registration_path(resource_name), class: "btn btn-sm btn-info" %><br />
   <% end %>
 </div>
 
-<div class="mt-4">
+<div class="mt-3">
   <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
     <%= link_to "パスワードを忘れましたか?", new_password_path(resource_name), class: "btn btn-sm btn-info" %><br />
   <% end %>
 </div>
 
-<div class="mt-4">
+<div class="mt-3">
   <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
     <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name), class: "btn btn-sm btn-info" %><br />
   <% end %>
 </div>
 
-<div class="mt-4">
+<div class="mt-3">
   <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
     <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: "btn btn-sm btn-info" %><br />
   <% end %>
 </div>
 
-<div class="mt-4">
+<div class="mt-3">
   <%- if devise_mapping.omniauthable? %>
     <%- resource_class.omniauth_providers.each do |provider| %>
       <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), class: "btn btn-sm btn-info" %><br />

--- a/app/views/impressions/index.html.erb
+++ b/app/views/impressions/index.html.erb
@@ -5,28 +5,25 @@
 <% end %>
 
 <% @impressions.each do |impression| %>
-  <div class="row  justify-content-md-center">
-    <div class="col-12 col-md-5 col-lg-5">
-      <% if impression.image? %> 
-        <p><%= image_tag impression.image.url %></p>
-      <% else %>
-        <p><%= image_tag "/assets/no_image_square.jpg", :size => '250x250' %></p>
-      <% end %>
-    </div>
-
-    <div class="col-12 col-md-5 col-lg-5 impression-text">
-      <div class="row btn btn-secondary">
+  <div class="justify-content-md-center">
+    <div class="row">
+      <div class="btn btn-info mx-auto">
         <h5>
           <%= MySchedule.find_id(impression).date %> &nbsp;
           <%= Spot.find(impression.spot_id).name %>
         </h5>
       </div>
-      <div class="mt-3">
-        <textarea readonly><%= impression.text %></textarea>
-      </div>
-      <div class="mt-4">
-        <p>投稿者:<%= User.id_name(MySchedule.find_id(impression)) %></p>
-        <p>投稿時間：<%= impression.created_at.to_s(:datetime_jp) %></p>
+    </div>
+    <div class="row">
+      <%= render 'shared/impression_image', impression: impression %>
+      <div class="col-12 col-md-5 col-lg-5 impression-text mx-auto">
+        <div class="mt-3">
+          <textarea readonly><%= impression.text %></textarea>
+        </div>
+        <div class="mt-4">
+          <p>投稿者:<%= User.id_name(MySchedule.find_id(impression)) %></p>
+          <p>投稿時間：<%= impression.created_at.to_s(:datetime_jp) %></p>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/model_courses/index.html.erb
+++ b/app/views/model_courses/index.html.erb
@@ -4,11 +4,15 @@
   <h5><%= link_to "ホームへ戻る", root_path %></h5>
 <% end %>
 
-<div class="m-3 mx-5">
-<h2>どの地域に行きたいですか？</h2>
-  <% @areas.each do |area| %>
-    <div class="m-4">
-      <p><%= link_to area.name, model_course_path(area.id), class: "btn btn-lg btn-success" %></p>
+<div class="row m-3 mx-5">
+  <div class="col-12 col-sm-12 col-md-12 col-lg-12">
+    <div class="card border border-0 mb-3 overflow-auto mx-auto text-center">
+      <div class="model-index-text">どの地域に行きたいですか？</div>
+      <% @areas.each do |area| %>
+        <div class="m-3">
+          <p><%= link_to area.name, model_course_path(area.id), class: "btn btn-lg btn-success" %></p>
+        </div>
+      <% end %>
     </div>
-  <% end %>
+  </div>
 </div>

--- a/app/views/model_courses/show.html.erb
+++ b/app/views/model_courses/show.html.erb
@@ -1,18 +1,16 @@
+<% if current_user %>
+  <h5><%= link_to "地域選択画面へ戻る", model_courses_path %></h5>
+<% else %>
+  <h5><%= link_to "ホームへ戻る", root_path %></h5>
+<% end %>
 <div class="text-center">
-  <% if current_user %>
-    <h5><%= link_to "地域選択画面へ戻る", model_courses_path %></h5>
-  <% else %>
-    <h5><%= link_to "ホームへ戻る", root_path %></h5>
-  <% end %>
   <div class="row">
     <div class="col-12 col-sm-12 col-md-12 col-lg-6 mx-auto">
       <% @courses_in_area.each do |course| %>
         <div class="row">
           <div class="card border-dark mt-4 pb-3" style="width:90%; height:40%;">  
             <% course.course_routes.each do |course_spot| %>
-              <button class="btn btn-info btn-lg m-3" disabled >
-                <b><%= course_spot.order %>. <%= course_spot.spot.name %></b>
-              </button>
+              <%= render 'shared/travel_spot_name_and_order', course_spot: course_spot %>
               <%= render 'shared/show_to_next_distance_and_time', course_spot: course_spot %>
             <% end %>
             <div class="mt-3">

--- a/app/views/my_travel_courses/show.html.erb
+++ b/app/views/my_travel_courses/show.html.erb
@@ -4,21 +4,24 @@
   <h5><%= link_to "ホームへ戻る", root_path %></h5>
 <% end %>
 <div class="text-center">
-  <h4>日程： <%= @schedule.date %></h4>
+  <h3>旅行日： <%= @schedule.date %></h3>
   <% @course.each do |course_spot| %>
-    <div class="row">
-      <h5><%= course_spot.order %>. <%= course_spot.spot.name %></h5>
-      <% if @schedule.gone %>
-        <div class="mx-5">
-          <%= link_to "感想の入力", new_impression_path(course_spot), class: "btn btn-secondary btn-sm" %>
+    <div class="row justify-content-md-center">
+      <div class="col">
+        <button class="btn btn-info btn-lg m-3" style="width: 50%;" disabled >
+          <b><%= course_spot.order %>. <%= course_spot.spot.name %></b>
+        </button>
+
+        <div class="mx-5 mb-3">
+          <% if @schedule.gone %>
+            <%= link_to "感想の入力", new_impression_path(course_spot), class: "btn btn-secondary" %>
+          <% else %>
+            <%= link_to "コースの修正", edit_my_travel_course_path(course_spot, course_ids: @course.ids.sort), class: "btn btn-secondary" %>
+          <% end %>
         </div>
-      <% else %>
-        <div class="mx-5">
-          <%= link_to "コースの修正", edit_my_travel_course_path(course_spot, course_ids: @course.ids.sort), class: "btn btn-secondary btn-sm" %>
-        </div>
-      <% end %>
+      </div>
     </div>
-    <div class="row">
+    <div class="row justify-content-md-center">
       <div class="col-12 col-sm-12 col-md-4 col-lg-4">
         <%= render 'shared/show_to_next_distance_and_time', course_spot: course_spot %>
       </div>
@@ -36,7 +39,7 @@
     <hr>
   <% end %>
   <% unless @schedule.gone %>
-    <div>
+    <div class="mb-3">
       <%= button_to "旅行終了", my_travel_courses_gone_flag_path(@schedule), class: "btn btn-success" %>
     </div>
   <% end %>

--- a/app/views/my_travel_courses/show.html.erb
+++ b/app/views/my_travel_courses/show.html.erb
@@ -8,33 +8,24 @@
   <% @course.each do |course_spot| %>
     <div class="row justify-content-md-center">
       <div class="col">
-        <button class="btn btn-info btn-lg m-3" style="width: 50%;" disabled >
-          <b><%= course_spot.order %>. <%= course_spot.spot.name %></b>
-        </button>
-
-        <div class="mx-5 mb-3">
-          <% if @schedule.gone %>
-            <%= link_to "感想の入力", new_impression_path(course_spot), class: "btn btn-secondary" %>
-          <% else %>
-            <%= link_to "コースの修正", edit_my_travel_course_path(course_spot, course_ids: @course.ids.sort), class: "btn btn-secondary" %>
-          <% end %>
-        </div>
-      </div>
+        <%= render 'shared/travel_spot_name_and_order', course_spot: course_spot %>
+        <% if @schedule.gone %>
+          <%= link_to "感想の入力", new_impression_path(course_spot), class: "btn btn-secondary ml-5" %>
+        <% else %>
+          <%= link_to "コースの修正", edit_my_travel_course_path(course_spot, course_ids: @course.ids.sort), class: "btn btn-secondary ml-3" %>
+        <% end %>
+      </div> 
     </div>
     <div class="row justify-content-md-center">
-      <div class="col-12 col-sm-12 col-md-4 col-lg-4">
-        <%= render 'shared/show_to_next_distance_and_time', course_spot: course_spot %>
-      </div>
       <% if course_spot.fill_in_impression %>
-        <div class="col-12 col-sm-12 col-md-4 col-lg-4">
+        <%= render 'shared/impression_image',
+          impression: Impression.find_by(my_schedule_id: @schedule.id, spot_id: course_spot.spot_id)
+        %>
+        <div class="col-12 col-sm-12 col-md-12 col-lg-5 mt-5 px-3">
           <textarea readonly><%= Impression.find_by(my_schedule_id: @schedule.id, spot_id: course_spot.spot_id).text %></textarea>
         </div>
-        <% if Impression.find_by(my_schedule_id: @schedule.id, spot_id: course_spot.spot_id).image.present? %>
-          <div class="col-12 col-sm-12 col-md-4 col-lg-4">
-            <%= image_tag Impression.find_by(my_schedule_id: @schedule.id, spot_id: course_spot.spot_id).image.url, :size => '200x200' %>
-          </div>
-        <% end %>
       <% end %>
+      <%= render 'shared/show_to_next_distance_and_time', course_spot: course_spot %>
     </div>
     <hr>
   <% end %>

--- a/app/views/shared/_impression_image.html.erb
+++ b/app/views/shared/_impression_image.html.erb
@@ -1,0 +1,7 @@
+<div class="col-12 col-md-5 col-lg-5">
+  <% if impression.image? %>
+    <p><%= image_tag impression.image.url %></p>
+  <% else %>
+    <p><%= image_tag "/assets/no_image_square.jpg", :size => '250x250' %></p>
+  <% end %>
+</div>

--- a/app/views/shared/_show_to_next_distance_and_time.html.erb
+++ b/app/views/shared/_show_to_next_distance_and_time.html.erb
@@ -1,6 +1,6 @@
-<div class="text-left mx-5">
+<div class="text-center">
   <% if course_spot.next_distance != 0 && course_spot.next_time != 0%>
-    ⇓ 距離: <%= course_spot.next_distance %> km <br>
+    <%= "　⇓　　 距離　　　:" %> <%= course_spot.next_distance %> km <br>
     ⇓ 車での移動時間: <%= course_spot.next_time %> 分
   <% end %>
 </div>

--- a/app/views/shared/_travel_spot_name_and_order.html.erb
+++ b/app/views/shared/_travel_spot_name_and_order.html.erb
@@ -1,0 +1,3 @@
+<button class="btn btn-info btn-lg m-3" disabled>
+  <b><%= course_spot.order %>. <%= course_spot.spot.name %></b>
+</button>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -1,8 +1,4 @@
-<% if current_user %>
-  <h5><%= link_to "観光地一覧へ戻る", spots_path %></h5>
-<% else %>
-  <h5><%= link_to "ホームへ戻る", root_path %></h5>
-<% end %>
+<h5><%= link_to "観光地一覧へ戻る", spots_path %></h5>
 <div class="row">
   <div class="col-12 col-md-5 col-lg-5">
     <div class="card border-dark mb-3 p-3" style="margin: 1rem">

--- a/app/views/users/_plan_course_button.html.erb
+++ b/app/views/users/_plan_course_button.html.erb
@@ -8,7 +8,7 @@
       <%= link_to "予定の削除",
         my_schedule_path(schedule.id),
         method: :delete,
-        data:{ confirm: "削除しますか？" },
+        data:{ confirm: "選択した予定を削除しますか？" },
         class: "btn btn-secondary"
       %>
     </div>

--- a/app/views/users/_show_course.html.erb
+++ b/app/views/users/_show_course.html.erb
@@ -2,7 +2,11 @@
   <b><p><h5>
     日程：<%= schedule.date %>
     <button class="btn btn-info m-2 btn-sm" disabled >
-      <%= MyTravelCourse.gone_text(schedule.gone) %>
+      <% if schedule.gone %>
+        旅行完了
+      <% else %>
+        旅行予定
+      <% end %>
     </button>
   </h5></p></b>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,9 +1,9 @@
 ja:
   devise:
     sessions:
-      signed_in: ''
-      signed_out: ''
-      
+      signed_in: ""
+      signed_out: ""
+
   views:
     pagination:
       first: "&laquo; 最初"
@@ -15,8 +15,8 @@ ja:
   helpers:
     label:
       user:
-        nickname: 名前
-        email: メールアドレス
-        password: パスワード
+        nickname: "　　名　前　　　"
+        email: "　メールアドレス"
+        password: "　パスワード　　"
         password_confirmation: パスワード(確認)
         remember_me: パスワードを記憶


### PR DESCRIPTION
# 内容
- 感想画面　観光地名、画像、感想テキストの表示配置組み合わせ変更
- 感想一覧画面とマイページの感想画面構成統一
- 新規登録、ログイン画面のボタンの余白修正
